### PR TITLE
In Progress: Add an initial tour to the solver 

### DIFF
--- a/GLNScmd.jl
+++ b/GLNScmd.jl
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-using GLNS
+include("./src/GLNS.jl")
+
+using .GLNS
 
 """
 Optional Flags -- values are given in square brackets []  

--- a/GLNScmd.jl
+++ b/GLNScmd.jl
@@ -50,7 +50,7 @@ function parse_cmd(ARGS)
 	end
 	int_flags = ["-max_time", "-trials", "-restarts", "-verbose", "-budget", "-num_iterations"]
 	float_flags = ["-epsilon", "-reopt"]
-	string_flags = ["-mode", "-output", "-noise", "-devel"]
+	string_flags = ["-mode", "-output", "-noise", "-devel", "-init_tour_file"]
 	filename = ""
 	optional_args = Dict{Symbol, Any}()
 	for arg in ARGS

--- a/GLNScmd.jl
+++ b/GLNScmd.jl
@@ -50,7 +50,7 @@ function parse_cmd(ARGS)
 	end
 	int_flags = ["-max_time", "-trials", "-restarts", "-verbose", "-budget", "-num_iterations"]
 	float_flags = ["-epsilon", "-reopt"]
-	string_flags = ["-mode", "-output", "-noise", "-devel", "-init_tour_file"]
+	string_flags = ["-mode", "-output", "-noise", "-devel", "-init_tour_file", "-init_tour"]
 	filename = ""
 	optional_args = Dict{Symbol, Any}()
 	for arg in ARGS

--- a/src/GLNS.jl
+++ b/src/GLNS.jl
@@ -43,9 +43,17 @@ function solver(problem_instance; args...)
 	setdist = set_vertex_dist(dist, num_sets, membership)
 	powers = initialize_powers(param)
 
+	init_tour_seed = try_read_input_tour(param, dist)
+
 	while count[:cold_trial] <= param[:cold_trials]
-		# build tour from scratch on a cold restart
-		best = initial_tour!(lowest, dist, sets, setdist, count[:cold_trial], param)
+		
+		if count[:cold_trial] == 1 && init_tour_seed !== nothing
+			best = init_tour_seed
+		else
+			# build tour from scratch on a cold restart
+			best = initial_tour!(lowest, dist, sets, setdist, count[:cold_trial], param)
+		end
+
 		# print_cold_trial(count, param, best)
 		phase = :early
 
@@ -70,10 +78,10 @@ function solver(problem_instance; args...)
 			while count[:latest_improvement] <= (count[:first_improvement] ?
 				  param[:latest_improvement] : param[:first_improvement])
 
-				if iter_count > param[:num_iterations]/2 && phase == :early
+				if phase == :early && iter_count > param[:num_iterations]/2
 					phase = :mid  # move to mid phase after half iterations
 				end
-				trial = remove_insert(current, best, dist, membership, setdist, sets, powers, param, phase)
+				trial = remove_insert(current, dist, membership, setdist, sets, powers, param, phase)
 
 		        # decide whether or not to accept trial
 				if accepttrial_noparam(trial.cost, current.cost, param[:prob_accept]) ||

--- a/src/GLNS.jl
+++ b/src/GLNS.jl
@@ -49,6 +49,7 @@ function solver(problem_instance; args...)
 		
 		if count[:cold_trial] == 1 && init_tour_seed !== nothing
 			best = init_tour_seed
+			lowest = init_tour_seed
 		else
 			# build tour from scratch on a cold restart
 			best = initial_tour!(lowest, dist, sets, setdist, count[:cold_trial], param)

--- a/src/insertion_deletion.jl
+++ b/src/insertion_deletion.jl
@@ -16,7 +16,7 @@
 Select a removal and an insertion method using powers, and then perform
 removal followed by insertion on tour.  Operation done in place.
 """
-function remove_insert(current::Tour, best::Tour, dist::Array{Int64,2}, member::Array{Int64,1},
+function remove_insert(current::Tour, dist::Array{Int64,2}, member::Array{Int64,1},
 						setdist::Distsv, sets::Array{Any,1},
 						powers, param::Dict{Symbol,Any}, phase::Symbol)
 	# make a new tour to perform the insertion and deletion on
@@ -248,7 +248,6 @@ function initial_tour!(lowest::Tour, dist::Array{Int64, 2}, sets::Array{Any, 1},
 	lowest.cost > best.cost && (lowest = best)
 	return best
 end
-
 
 """
 Randomly shuffle the sets, and then insert the best vertex from each set back into

--- a/src/insertion_deletion.jl
+++ b/src/insertion_deletion.jl
@@ -232,7 +232,7 @@ end
 ############ Initial Tour Construction ##########################
 
 """build tour from scratch on a cold restart"""
-function initial_tour!(lowest::Tour, dist::Array{Int64, 2}, sets::Array{Any, 1},
+function initial_tour!(dist::Array{Int64, 2}, sets::Array{Any, 1},
 						setdist::Distsv, trial_num::Int64, param::Dict{Symbol,Any})
 	sets_to_insert = collect(1:param[:num_sets])
 	best = Tour(Int64[], typemax(Int64))
@@ -245,7 +245,6 @@ function initial_tour!(lowest::Tour, dist::Array{Int64, 2}, sets::Array{Any, 1},
 		random_insertion!(best.tour, sets_to_insert, dist, sets, setdist)
 	end
 	best.cost = tour_cost(best.tour, dist)
-	lowest.cost > best.cost && (lowest = best)
 	return best
 end
 

--- a/src/parameter_defaults.jl
+++ b/src/parameter_defaults.jl
@@ -115,6 +115,7 @@ function parameter_settings(num_vertices, num_sets, sets, problem_instance, args
 	param[:num_sets] = num_sets
 	param[:num_vertices] = num_vertices
 	param[:output_file] = get(args, :output, "None")
+	param[:init_tour_file] = get(args, :init_tour_file, "None")
 	param[:print_output] = get(args, :verbose, 3)
 	param[:epsilon] = get(args, :epsilon, 0.5)
 	param[:noise] = get(args, :noise, "Add")

--- a/src/parse_print.jl
+++ b/src/parse_print.jl
@@ -503,6 +503,25 @@ function progress_bar(trials, progress, cost, time)
 	print(" ", progress_bar, "  Cost = ", cost, "  Time = ", time, " sec      \r")
 end
 
+"""
+Read an input tour file as an initial seed for every trial
+"""
+function try_read_input_tour(param::Dict{Symbol,Any}, dist::Array{Int64, 2},)
+
+    if(param[:init_tour_file] == "None")
+        return nothing
+    end
+
+    s = open(param[:init_tour_file], "r")
+    tour_order_str = split(read(s, String), ",")
+    tour_order = [parse(Int64, vertex) for vertex in tour_order_str]
+    seed_tour = Tour(tour_order, typemax(Int64))
+    seed_tour.cost = tour_cost(seed_tour.tour, dist)
+
+    println("Initial Tour Loaded")
+
+    return seed_tour
+end
 
 """print tour summary at end of execution"""
 function print_summary(lowest::Tour, timer::Float64, member::Array{Int64,1},

--- a/src/parse_print.jl
+++ b/src/parse_print.jl
@@ -525,7 +525,7 @@ end
 
 """print tour summary at end of execution"""
 function print_summary(lowest::Tour, timer::Float64, member::Array{Int64,1},
-						param::Dict{Symbol,Any})
+						param::Dict{Symbol,Any}, best_sol_time::Float64)
 	if param[:print_output] == 3 && !param[:timeout] && !param[:budget_met]
 		progress_bar(param[:cold_trials], 1.0, lowest.cost, round(timer, digits=1))
 	end
@@ -541,18 +541,20 @@ function print_summary(lowest::Tour, timer::Float64, member::Array{Int64,1},
 					lowest.tour : "printed to " * param[:output_file])
 			println("Output File       : ",  param[:output_file])
 			println("Tour Ordering     : ",  order_to_print)
+            println("Best Solution Time: ", best_sol_time)
 			println("-----------------------------------")
 		end
 		if param[:output_file] != "None"
 			s = open(param[:output_file], "w")
-			write(s, "Problem Instance : ", param[:problem_instance], "\n")
-			write(s, "Vertices         : ", string(param[:num_vertices]), "\n")
-			write(s, "Sets             : ", string(param[:num_sets]), "\n")
-			write(s, "Comment          : To avoid ~0.5sec startup time, use the Julia REPL\n")
-			write(s, "Host Computer    : ", gethostname(), "\n")
-			write(s, "Solver Time      : ", string(round(timer, digits=3)), " sec\n")
-			write(s, "Tour Cost        : ", string(lowest.cost), "\n")
-			write(s, "Tour             : ", string(lowest.tour))
+			write(s, "Problem Instance    : ", param[:problem_instance], "\n")
+			write(s, "Vertices            : ", string(param[:num_vertices]), "\n")
+			write(s, "Sets                : ", string(param[:num_sets]), "\n")
+			write(s, "Comment             : To avoid ~0.5sec startup time, use the Julia REPL\n")
+			write(s, "Host Computer       : ", gethostname(), "\n")
+			write(s, "Solver Time         : ", string(round(timer, digits=3)), " sec\n")
+			write(s, "Tour Cost           : ", string(lowest.cost), "\n")
+			write(s, "Tour                : ", string(lowest.tour), "\n")
+            write(s, "Best Solution Time  : ", string(best_sol_time))
 			close(s)
 		end
 	end


### PR DESCRIPTION
This pull request is to add the functionality to warm-start the solver with a seed tour. This also adds functionality to record the time at which the final solution (i.e. the best tour) was found. 